### PR TITLE
feat(header): add simple scroll indicator

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -6,6 +6,7 @@
 html {
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
+    scroll-behavior: smooth;
 }
 
 a {
@@ -49,6 +50,8 @@ a:hover {
 /* Header                                              */
 /*******************************************************/
 .Header {
+    position: relative;
+
     display: flex;
     flex-direction: column;
     justify-content: center;
@@ -77,6 +80,20 @@ a:hover {
     margin-top: 2rem;
 }
 
+.Header-scrollIndicator {
+    position: absolute;
+    bottom: 6rem;
+
+    padding: .2rem;
+    font-size: 1.2rem;
+
+    opacity: 0;
+    animation-name: arise;
+    animation-delay: 1.5s;
+    animation-duration: 2s;
+    animation-fill-mode: forwards;
+}
+
 @media screen and (min-width: 750px) {
     .HeaderTitle {
         --title-font-size: 4rem;
@@ -86,6 +103,14 @@ a:hover {
     }
 }
 
+@keyframes arise {
+    from {
+        opacity: 0;
+    }
+    to {
+        opacity: 1;
+    }
+}
 /*******************************************************/
 /* About                                               */
 /*******************************************************/

--- a/index.html
+++ b/index.html
@@ -51,9 +51,10 @@
           <i class="fas fa-envelope"></i>
         </a>
       </div>
+      <a href="#about" class="Header-scrollIndicator">↓</a>
     </header>
 
-    <section class="Section About">
+    <section id="about" class="Section About">
       <p>Hello! Je suis Colin, développeur front-end indépendant.</p>
       <p>
         <a href="https://agilemanifesto.org/">Agiliste</a> et


### PR DESCRIPTION
Add simple scroll indicator in header.
It appear later with a small animation.
Change scroll behavior to smooth so scroll is smooth when touching the link. Nevertheless it does not work on all browsers. A polyfill might be found later on